### PR TITLE
Potential fix for code scanning alert no. 1 to 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/svg-converter-demo.yml
+++ b/.github/workflows/svg-converter-demo.yml
@@ -2,6 +2,7 @@ name: 🎨 SVG Converter Pro - Enhanced Demo
 
 permissions:
   contents: read
+  actions: write
 
 on:
   push:

--- a/.github/workflows/svg-converter-demo.yml
+++ b/.github/workflows/svg-converter-demo.yml
@@ -1,5 +1,8 @@
 name: 🎨 SVG Converter Pro - Enhanced Demo
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/kjanat/action-svg_converter/security/code-scanning/1](https://github.com/kjanat/action-svg_converter/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the workflow's operations (e.g., checking out the repository and processing files), it only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
