### PR TITLE
Fix output encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A powerful, secure, and high-performance GitHub Action that converts SVG files t
 - **🔒 Security-first**: Input validation, path traversal protection, and safe processing
 - **🎛️ Highly configurable**: Custom sizes, TypeScript support, multiple PNGs
 - **📝 Smart naming**: Auto-detects names or uses custom base names
-- **🎨 Professional logging**: Colored output with clear progress indicators and debug mode
+- **🎨 Professional logging**: Colored output with clear progress indicators and debug mode (auto-disables if color isn't supported or `NO_COLOR` is set)
 - **📊 Comprehensive outputs**: JSON array of created files and detailed summaries
 - **🛡️ Robust error handling**: Graceful failure handling with detailed error messages
 - **♻️ Clean operations**: Automatic cleanup of temporary files

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,12 +20,39 @@ SCRIPT_NAME="$(basename "$0")"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Colors for output
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly YELLOW='\033[1;33m'
-readonly BLUE='\033[0;34m'
-readonly BOLD='\033[1m'
-readonly NC='\033[0m' # No Color
+# ANSI color codes (disabled if unsupported)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# Detect color support
+supports_color() {
+    if [[ -n "${NO_COLOR:-}" ]]; then
+        return 1
+    fi
+
+    if [[ -t 1 ]] && command -v tput >/dev/null 2>&1; then
+        local colors
+        colors=$(tput colors)
+        [[ -n "$colors" && $colors -ge 8 ]] && return 0
+    fi
+
+    return 1
+}
+
+if ! supports_color; then
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    BOLD=''
+    NC=''
+fi
+
+readonly RED GREEN YELLOW BLUE BOLD NC
 
 # Configuration constants
 readonly MAX_SIZE=8192

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -576,7 +576,7 @@ set_outputs() {
         local summary_text
 
         # Convert array to JSON
-        files_json=$(printf '%s\n' "${CREATED_FILES[@]}" | jq -R . | jq -s .)
+        files_json=$(printf '%s\n' "${CREATED_FILES[@]}" | jq -R . | jq -s -c .)
 
         # Create summary text
         summary_text=$(printf "Converted %s to %d files:\n%s" "$SVG_PATH" "${#CREATED_FILES[@]}" "$(printf '%s\n' "${CONVERSION_SUMMARY[@]}")")


### PR DESCRIPTION
## Summary
- fix multi-line output format for `files-created`

## Testing
- `bash -n entrypoint.sh`
- `./entrypoint.sh --help`

------
https://chatgpt.com/codex/tasks/task_e_684dbcf3d26c83208ba76d4a054370b3